### PR TITLE
fix: define `exports.require`

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
   "exports": {
     ".": {
       "types": "./index.d.ts",
-      "import": "./lib/index.mjs"
+      "import": "./lib/index.mjs",
+      "require": "./lib/index.mjs"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
It does not really make sense to export ESM code like this, but jest chokes without this when used in tests. 