### PR TITLE
ci: use pnpm to run release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,4 +35,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node --run release
+        run: pnpm run release


### PR DESCRIPTION
Node version we're using doesn't support --run