### PR TITLE
ci: use semrel supported node version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           run_install: false
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
-          node-version: 20
+          node-version: 22.16
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - run: pnpm build


### PR DESCRIPTION
> [semantic-release]: node version ^22.14.0 || >= 24.10.0 is required. Found v20.19.6.
