### PR TITLE
chore: add missing package name and use pre-release versions

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,6 @@
 {
-  "branches": ["exodus-4.1.9"],
+  "repositoryUrl": "git@github.com:ExodusMovement/zod.git",
+  "branches": ["main", { "name": "exodus", "prerelease": true }],
   "plugins": [
     [
       "@semantic-release/commit-analyzer",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "@exodus/zod",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.12.1",


### PR DESCRIPTION
Picking up the missing work here; we were missing the package name and need to set `prelease: true` to use our existing version scheme. I also renamed the branch from `exodus-4.1.9` to `exodus` because semrel uses the branch name to derive the pre-release suffix.  